### PR TITLE
Package size optimisation

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "@react-native-community/eslint-config": "^0.0.7",
     "@release-it/conventional-changelog": "^1.1.0",
     "@types/jest": "^25.1.2",
-    "@types/lodash": "^4.14.155",
+    "@types/lodash.get": "^4.4.6",
+    "@types/lodash.set": "^4.3.6",
     "@types/react": "^16.9.19",
     "@types/react-native": "0.61.10",
     "commitlint": "^8.3.4",
@@ -103,7 +104,8 @@
   },
   "dependencies": {
     "@expo/results": "^1.0.0",
-    "lodash": "^4.17.15",
+    "lodash.get": "^4.4.2",
+    "lodash.set": "^4.3.2",
     "swr": "^0.2.0"
   }
 }

--- a/src/helpers/doc-date-parser.ts
+++ b/src/helpers/doc-date-parser.ts
@@ -1,4 +1,5 @@
-import { set, get } from 'lodash'
+import get from 'lodash.get'
+import set from 'lodash.set'
 
 export function withDocumentDatesParsed<Data extends object>(
   data: Data,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2129,10 +2129,24 @@
   dependencies:
     "@types/node" "*"
 
-"@types/lodash@^4.14.155":
-  version "4.14.155"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.155.tgz#e2b4514f46a261fd11542e47519c20ebce7bc23a"
-  integrity sha512-vEcX7S7aPhsBCivxMwAANQburHBtfN9RdyXFk84IJmu2Z4Hkg1tOFgaslRiEqqvoLtbCBi6ika1EMspE+NZ9Lg==
+"@types/lodash.get@^4.4.6":
+  version "4.4.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.get/-/lodash.get-4.4.6.tgz#0c7ac56243dae0f9f09ab6f75b29471e2e777240"
+  integrity sha512-E6zzjR3GtNig8UJG/yodBeJeIOtgPkMgsLjDU3CbgCAPC++vJ0eCMnJhVpRZb/ENqEFlov1+3K9TKtY4UdWKtQ==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash.set@^4.3.6":
+  version "4.3.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.set/-/lodash.set-4.3.6.tgz#33e635c2323f855359225df6a5c8c6f1f1908264"
+  integrity sha512-ZeGDDlnRYTvS31Laij0RsSaguIUSBTYIlJFKL3vm3T2OAZAQj2YpSvVWJc0WiG4jqg9fGX6PAPGvDqBcHfSgFg==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.158"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.158.tgz#b38ea8b6fe799acd076d7a8d7ab71c26ef77f785"
+  integrity sha512-InCEXJNTv/59yO4VSfuvNrZHt7eeNtWQEgnieIA+mIC+MOWM9arOWG2eQ8Vhk6NbOre6/BidiXhkZYeDY9U35w==
 
 "@types/long@^4.0.0":
   version "4.0.1"


### PR DESCRIPTION
This PR replaces the lodash package which is currently responsible for 70% of the package size to lodash.get & lodash.set packages. This change would result a total size reduction of about ~60%.

@nandorojo/swr-firestore@0.10.0 currently sitting at just over 100K
https://bundlephobia.com/result?p=@nandorojo/swr-firestore@0.10.0