### PR TITLE
Firestore Converters

### DIFF
--- a/src/hooks/use-swr-collection.ts
+++ b/src/hooks/use-swr-collection.ts
@@ -468,7 +468,7 @@ export const useCollection = <
 
       return batch.commit()
     },
-    [listen, mutate, path]
+    [listen, mutate, path, documentDataConverter]
   )
 
   return {

--- a/src/hooks/use-swr-collection.ts
+++ b/src/hooks/use-swr-collection.ts
@@ -5,14 +5,13 @@ import { useRef, useEffect, useMemo, useCallback } from 'react'
 import { empty } from '../helpers/empty'
 import { collectionCache } from '../classes/Cache'
 
-type Document<T = {}> = T & { id: string }
+import { Document, Converter } from '../types'
 
 import {
   FieldPath,
   OrderByDirection,
   WhereFilterOp,
   Query,
-  FirestoreDataConverter,
 } from '@firebase/firestore-types'
 import { isDev } from '../helpers/is-dev'
 import { withDocumentDatesParsed } from '../helpers/doc-date-parser'
@@ -36,8 +35,6 @@ type WhereItem<Doc extends object = {}, Key = keyof Doc> = [
 ]
 type WhereArray<Doc extends object = {}> = WhereItem<Doc>[]
 type WhereType<Doc extends object = {}> = WhereItem<Doc> | WhereArray<Doc>
-
-type ConverterType<Doc extends object = {}> = FirestoreDataConverter<Doc>
 
 type Ref<Doc extends object = {}> = {
   limit?: number
@@ -84,7 +81,7 @@ const createRef = <Doc extends object = {}>(
     documentDataConverter,
   }: {
     isCollectionGroup?: boolean
-    documentDataConverter?: ConverterType<Doc>
+    documentDataConverter?: Converter<Doc>
   } = empty.object
 ) => {
   let ref: Query = fuego.db.collection(path)
@@ -157,7 +154,7 @@ const createListenerAsync = async <Doc extends Document = Document>(
     isCollectionGroup = false,
   }: {
     parseDates?: (string | keyof Doc)[]
-    documentDataConverter?: ConverterType<Doc>
+    documentDataConverter?: Converter<Doc>
     isCollectionGroup?: boolean
   }
 ): Promise<ListenerReturnType<Doc>> => {
@@ -232,7 +229,7 @@ export const useCollection = <
      * Default: `false`
      */
     listen?: boolean
-    documentDataConverter?: ConverterType<Doc>
+    documentDataConverter?: Converter<Doc>
     /**
      * An array of key strings that indicate where there will be dates in the document.
      *

--- a/src/hooks/use-swr-collection.ts
+++ b/src/hooks/use-swr-collection.ts
@@ -451,7 +451,11 @@ export const useCollection = <
 
       docsToAdd.forEach(({ id, ...doc }) => {
         // take the ID out of the document
-        batch.set(ref.doc(id), doc)
+        let docRef = ref.doc(id)
+        if (converter) {
+          docRef = docRef.withConverter(converter)
+        }
+        batch.set(docRef, doc)
       })
 
       return batch.commit()

--- a/src/hooks/use-swr-document.ts
+++ b/src/hooks/use-swr-document.ts
@@ -1,15 +1,13 @@
 import useSWR, { mutate, ConfigInterface } from 'swr'
-import { SetOptions, FirestoreDataConverter } from '@firebase/firestore-types'
+import { SetOptions } from '@firebase/firestore-types'
 import { fuego } from '../context'
 import { useRef, useEffect, useCallback } from 'react'
 import { empty } from '../helpers/empty'
-import { Document } from '../types/Document'
+import { Document, Converter } from '../types'
 import { collectionCache } from '../classes/Cache'
 import { isDev } from '../helpers/is-dev'
 import { withDocumentDatesParsed } from '../helpers/doc-date-parser'
 import { deleteDocument } from './static-mutations'
-
-type ConverterType<Doc extends object = {}> = FirestoreDataConverter<Doc>
 
 type Options<Doc extends Document = Document> = {
   /**
@@ -29,7 +27,7 @@ type Options<Doc extends Document = Document> = {
     | string
     | keyof Omit<Doc, 'id' | 'exists' | 'hasPendingWrites'>
   )[]
-  documentDataConverter?: ConverterType<Doc>
+  documentDataConverter?: Converter<Doc>
 } & ConfigInterface<Doc | null>
 
 type ListenerReturnType<Doc extends Document = Document> = {
@@ -43,7 +41,7 @@ const createListenerAsync = async <Doc extends Document = Document>(
     | string
     | keyof Omit<Doc, 'id' | 'exists' | 'hasPendingWrites'>
   )[],
-  documentDataConverter?: ConverterType<Doc>
+  documentDataConverter?: Converter<Doc>
 ): Promise<ListenerReturnType<Doc>> => {
   return await new Promise(resolve => {
     let docRef = fuego.db.doc(path)

--- a/src/hooks/use-swr-document.ts
+++ b/src/hooks/use-swr-document.ts
@@ -298,7 +298,7 @@ export const useDocument = <
         docRef = docRef.withConverter(documentDataConverter)
       return docRef.set(data, options)
     },
-    [path, listen, connectedMutate]
+    [path, listen, connectedMutate, documentDataConverter]
   )
 
   /**
@@ -323,7 +323,7 @@ export const useDocument = <
         docRef = docRef.withConverter(documentDataConverter)
       return docRef.update(data)
     },
-    [listen, path, connectedMutate]
+    [listen, path, connectedMutate, documentDataConverter]
   )
 
   const connectedDelete = useCallback(() => {

--- a/src/types/Converter.ts
+++ b/src/types/Converter.ts
@@ -1,0 +1,5 @@
+import { firestore } from 'firebase'
+
+export type Converter<
+  Doc extends object = {}
+> = firestore.FirestoreDataConverter<Omit<Doc, 'exists' | 'hasPendingWrites'>>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,1 +1,2 @@
 export * from './Document'
+export * from './Converter'


### PR DESCRIPTION
Because I haven't already said it: Thanks @nandorojo for the sweet library!  I've quite enjoyed working with it.

I added support for `useDocument` and made the changes you requested in your prior comments.

### Concerns
I have two concerns with this:
- To my knowledge react-native does not yet support FirestoreDataConverters so there are potential issues with how the solution to #39 plays out
- Despite my best attempts (so far) I was unable to get typechecking to fail in this instance:

```
const result = useCollection<List>('lists', {
  listen: true,
  documentDataConverter: UserConverter,
});
```

where

```
export const UserConverter = {
  fromFirestore(
    snapshot: firebase.firestore.QueryDocumentSnapshot,
    options: firebase.firestore.SnapshotOptions = {},
  ): User  {
    return snapshot.data(options);
  },

  toFirestore(user: User): firebase.firestore.DocumentData {
    return user;
  },
};
```

In this instance I would like type checking to fail because the generic type passed to `useDocument` (`List`) does not match the return type of the converter's `fromFirestore` function (`User`).  I am _relatively_ new to typescript, so maybe I'm making a dumb mistake, all ears on how to protect against this type of usage.

### Testing
In addition to getting this working in my project _with_ converters, I also tested these changes on a prior version of my project (without converters) and I did not notice any difference in behavior (appears to be backwards compatible).  I also ran `yarn test` which passed but there doesn't seem to be much coverage so I'm not sure that says much.

I have not tested this in _any_ capacity in an expo/react-native based project.