### PR TITLE
Update 'Subscribe to a document' example

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ export default function User() {
   if (error) return <Text>Error!</Text>
   if (!data) return <Text>Loading...</Text>
 
-  return <Text>Name: {user.name}</Text>
+  return <Text>Name: {data.name}</Text>
 }
 ```
 


### PR DESCRIPTION
Fix "subscribe to a document" example.

I was confused for a bit trying to get attributes from my document using the object created to house the "id".

I think the return should be {data.name} in lieu of {user.name} unless there is supposed to be that functionality to feed the data to the object and I just implemented it wrong.