### PR TITLE
feat: Get id(s) from created document(s).

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,9 +214,9 @@ const { data, add } = useCollection('albums', {
   where: ['artist', '==', 'Drake'],
 })
 
-const onPress = () => {
+const onPress = async () => {
   // calling this will automatically update your global cache & Firestore
-  add({
+  const documentId = await add({
     title: 'Dark Lane Demo Tapes',
     artist: 'Drake',
     year: '2020',
@@ -639,7 +639,7 @@ _(optional)_ A dictionary with added options for the request. See the [options a
 
 Returns a dictionary with the following values:
 
-- `add(data)`: Extends the Firestore document [`add` function](https://firebase.google.com/docs/firestore/manage-data/add-data).
+- `add(data)`: Extends the Firestore document [`add` function](https://firebase.google.com/docs/firestore/manage-data/add-data). Returns the added document ID(s).
   - It also updates the local cache using SWR's `mutate`. This will prove highly convenient over the regular `add` function provided by Firestore.
 
 The returned dictionary also includes the following [from `useSWR`](https://github.com/zeit/swr#return-values):

--- a/src/hooks/use-swr-collection.ts
+++ b/src/hooks/use-swr-collection.ts
@@ -498,10 +498,13 @@ export const useCollection = <
    * - It also updates the local cache using SWR's `mutate`. This will prove highly convenient over the regular `add` function provided by Firestore.
    */
   const add = useCallback(
-    (data: Data | Data[]) => {
+    <T extends Data | Data[]>(
+      data: T
+    ): Promise<T extends Data ? string : string[]> | null => {
       if (!path) return null
 
-      const dataArray = Array.isArray(data) ? data : [data]
+      const multiple = Array.isArray(data)
+      const dataArray = multiple ? (data as T[]) : [data]
 
       const ref = fuego.db.collection(path)
 
@@ -529,7 +532,12 @@ export const useCollection = <
         batch.set(ref.doc(id), doc)
       })
 
-      return batch.commit()
+      return batch.commit().then(() => {
+        const ids = docsToAdd.map(({ id }) => id)
+        const returnValue = multiple ? ids : ids[0]
+
+        return returnValue as T extends Data ? string : string[]
+      })
     },
     [listen, mutate, path]
   )


### PR DESCRIPTION
On adding to a collection, the document ID is returned when a single
object is passed, and the set of document IDs is returned when multiple
objects are passed as an array.

Fixes #62.

---

Note: This is a clean branch of https://github.com/nandorojo/swr-firestore/pull/123

Closes https://github.com/nandorojo/swr-firestore/pull/123